### PR TITLE
Track demo SQL and verifier, ignore local state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Local agent/editor state
+.claude/
+.idea/
+.vscode/
+
+# Python
+__pycache__/
+*.pyc
+
+# OS
+.DS_Store

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,111 @@
+# CLAUDE.md
+
+## Project Overview
+
+This repository is a local Docker demo for running Apache Flink with Apache Paimon on MinIO, using MinIO as S3-compatible object storage. The goal is to keep a small, reproducible environment that proves Flink SQL can create and write Paimon tables backed by object storage.
+
+The project is intentionally lightweight. Prefer small, practical changes that make the demo easier to run, verify, and understand.
+
+## Important Files
+
+- `Dockerfile`: Builds the custom Flink image and installs the Paimon and Hadoop jars into `/opt/flink/lib/`.
+- `docker-compose.yml`: Starts MinIO, creates buckets, and runs Flink JobManager and TaskManager.
+- `conf/flink-conf.yaml`: Local Flink cluster configuration.
+- `README.md`: User-facing quick start and project explanation.
+- `FLINK_PAIMON_SETUP.md`: Setup notes and troubleshooting guidance. This file is currently untracked unless committed later.
+- `sql/`: SQL walkthrough files for creating/querying Paimon tables. This directory is currently untracked unless committed later.
+- `verify_test.py`: Local verification script. This file is currently untracked unless committed later.
+
+## Current Dependency Context
+
+The current checked-in Dockerfile uses:
+
+- Apache Flink `1.19.3`
+- Apache Paimon `1.2.0`
+- Java 17 Flink base image
+- MinIO images currently referenced as `latest`
+
+As of June 2026, this should be revisited. Paimon `1.4.1` publishes bundled jars for Flink `2.2`, `2.1`, `2.0`, `1.20`, `1.19`, and older lines. A conservative refresh path is likely Flink `1.20.4` with Paimon `1.4.1`; a more modern path is Flink `2.2.x` with Paimon `1.4.1`.
+
+When changing versions, keep the Flink image, Paimon jar artifact name, Paimon version, and README in sync.
+
+## Common Commands
+
+Build the custom Flink image:
+
+```bash
+docker compose build --no-cache
+```
+
+Start the local environment:
+
+```bash
+docker compose up -d
+```
+
+Open the Flink SQL client:
+
+```bash
+docker exec -it flink-jobmanager /opt/flink/bin/sql-client.sh embedded
+```
+
+Check running services:
+
+```bash
+docker compose ps
+```
+
+View logs:
+
+```bash
+docker compose logs jobmanager
+docker compose logs taskmanager
+docker compose logs minio
+```
+
+Stop the environment:
+
+```bash
+docker compose down
+```
+
+Reset local data:
+
+```bash
+docker compose down -v
+```
+
+## Development Guidance
+
+- Keep the README, SQL scripts, verifier, and MinIO warehouse paths aligned. The README currently describes a `user_events` example, while local SQL files use a `users` table.
+- Prefer one canonical demo path and make all documentation and tests point to it.
+- Pin container images instead of using `latest`.
+- Make jar downloads fail fast and verify downloaded artifacts where practical.
+- Treat `verify_test.py` as needing improvement: it should fail with a non-zero exit code when Flink, MinIO, the expected table, data files, or snapshots are missing.
+- Avoid committing local assistant/editor state such as `.claude/settings.local.json`.
+- Be careful with Docker volume cleanup. `docker compose down -v` deletes local MinIO data.
+
+## Open Cleanup Themes
+
+The repo has GitHub issues tracking the main cleanup work:
+
+- Pin container images and verify downloaded jars.
+- Update the Flink and Paimon dependency strategy.
+- Commit intended demo SQL files and the verifier, and ignore local settings.
+- Make README and SQL scripts describe the same demo.
+- Tighten Docker Compose startup dependencies and naming.
+- Add richer Paimon examples beyond a basic insert.
+- Replace `verify_test.py` with a real failing smoke test.
+- Document and tune the Flink configuration for the local demo.
+
+## Expected Demo Shape
+
+A strong version of this project should let a user run a small number of commands, then verify:
+
+- Flink Web UI is reachable on `http://localhost:8081`.
+- MinIO Console is reachable on `http://localhost:9001`.
+- Buckets such as `warehouse` and `checkpoints` exist.
+- Flink SQL can create a Paimon catalog backed by MinIO.
+- A Paimon table can be created, written to, queried, and inspected in object storage.
+- The verifier exits successfully only when the demo has actually produced expected Paimon data.
+

--- a/FLINK_PAIMON_SETUP.md
+++ b/FLINK_PAIMON_SETUP.md
@@ -1,0 +1,88 @@
+# Flink + Paimon Integration Guide
+
+## Critical Setup Requirements
+
+### 1. Docker Configuration
+- **File Permissions**: Ensure `conf/flink-conf.yaml` has proper permissions (`chmod 644`)
+- **Volume Mounts**: Mount config files directly, not directories
+- **Health Checks**: Use proper health checks for service dependencies
+
+### 2. Paimon Catalog Configuration
+```sql
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',  -- Must have trailing slash
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'  -- Required for MinIO
+);
+```
+
+### 3. Common Issues and Fixes
+
+#### Permission Denied on flink-conf.yaml
+- **Symptom**: `java.io.FileNotFoundException: /opt/flink/conf/flink-conf.yaml (Permission denied)`
+- **Fix**: Run `chmod 644 conf/flink-conf.yaml` before starting containers
+
+#### Warehouse Path Must Be Absolute
+- **Symptom**: `java.lang.IllegalArgumentException: path must be absolute`
+- **Fix**: Ensure warehouse path has trailing slash: `'warehouse' = 's3://warehouse/'`
+
+#### SQL Client Execution Mode
+- **Issue**: Queries fail in non-interactive mode
+- **Fix**: For batch queries, use `SET execution.runtime-mode=batch;`
+- **Note**: SET commands don't work in `-f` file mode with certain Flink versions
+
+### 4. Testing Data Flow
+
+#### Create Table with Primary Key
+```sql
+CREATE TABLE users (
+    user_id INT,
+    username STRING,
+    email STRING,
+    age INT,
+    registration_date TIMESTAMP(3),
+    PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+    'bucket' = '4',
+    'changelog-producer' = 'input'
+);
+```
+
+#### Verify Data in MinIO
+```bash
+# Check warehouse structure
+docker exec minio mc ls local/warehouse/test_db.db/users/
+
+# Expected directories:
+# - bucket-0/ bucket-1/ bucket-2/  (data buckets)
+# - manifest/  (table manifests)
+# - schema/    (table schema)
+# - snapshot/  (data snapshots)
+
+# Count data files
+docker exec minio sh -c "mc ls --recursive local/warehouse/test_db.db/users/ | grep -c 'data-'"
+```
+
+### 5. Verification Checklist
+- [ ] All containers running and healthy: `docker compose ps`
+- [ ] Flink UI accessible: `http://localhost:8081`
+- [ ] MinIO buckets created: `warehouse` and `checkpoints`
+- [ ] Catalog creation succeeds without errors
+- [ ] Data insertion jobs show as FINISHED in Flink UI
+- [ ] Data files present in MinIO storage
+- [ ] Multiple snapshots created after inserts/updates
+
+### 6. Key Dependencies
+- **Flink**: 1.19.3 (or compatible version)
+- **Paimon**: 1.2.0 (must match Flink version compatibility)
+- **Hadoop AWS**: Required for S3 filesystem support
+- **Dockerfile must include**: Paimon JARs in `/opt/flink/lib/`
+
+### 7. Important Notes
+- Catalogs are session-scoped in SQL Client - recreate in each session
+- Use `docker cp` to copy SQL files into containers for execution
+- Monitor job status via Flink REST API: `curl http://localhost:8081/jobs`
+- Check logs with: `docker compose logs [jobmanager|taskmanager]`

--- a/sql/batch_query.sql
+++ b/sql/batch_query.sql
@@ -1,0 +1,30 @@
+-- Create Paimon catalog
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+
+USE CATALOG paimon_catalog;
+USE test_db;
+
+-- Set execution mode to batch for query
+SET execution.runtime-mode=batch;
+
+-- Create a sink table to output results
+CREATE TEMPORARY TABLE print_sink (
+    user_id INT,
+    username STRING,
+    email STRING,
+    age INT,
+    registration_date TIMESTAMP(3)
+) WITH (
+    'connector' = 'print'
+);
+
+-- Insert query results into print sink to display them
+INSERT INTO print_sink
+SELECT * FROM users;

--- a/sql/query_users.sql
+++ b/sql/query_users.sql
@@ -1,0 +1,19 @@
+-- Create Paimon catalog
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+
+-- Use the Paimon catalog
+USE CATALOG paimon_catalog;
+USE test_db;
+
+-- Set result mode for queries
+SET sql-client.execution.result-mode=TABLEAU;
+
+-- Query all users
+SELECT * FROM users;

--- a/sql/test_paimon.sql
+++ b/sql/test_paimon.sql
@@ -1,0 +1,57 @@
+-- Create Paimon catalog using S3 (MinIO) storage
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+
+-- Switch to the Paimon catalog
+USE CATALOG paimon_catalog;
+
+-- Create a database
+CREATE DATABASE IF NOT EXISTS test_db;
+USE test_db;
+
+-- Create a Paimon table with primary key
+CREATE TABLE IF NOT EXISTS users (
+    user_id INT,
+    username STRING,
+    email STRING,
+    age INT,
+    registration_date TIMESTAMP(3),
+    PRIMARY KEY (user_id) NOT ENFORCED
+) WITH (
+    'bucket' = '4',
+    'changelog-producer' = 'input'
+);
+
+-- Insert test data
+INSERT INTO users VALUES
+    (1, 'alice', 'alice@example.com', 28, TIMESTAMP '2024-01-15 10:30:00'),
+    (2, 'bob', 'bob@example.com', 35, TIMESTAMP '2024-01-16 11:45:00'),
+    (3, 'charlie', 'charlie@example.com', 42, TIMESTAMP '2024-01-17 09:15:00'),
+    (4, 'diana', 'diana@example.com', 31, TIMESTAMP '2024-01-18 14:20:00'),
+    (5, 'edward', 'edward@example.com', 26, TIMESTAMP '2024-01-19 16:30:00');
+
+-- Set result mode for queries
+SET sql-client.execution.result-mode=TABLEAU;
+
+-- Query the data
+SELECT * FROM users;
+
+-- Update some records
+INSERT INTO users VALUES
+    (2, 'bob_updated', 'bob.updated@example.com', 36, TIMESTAMP '2024-02-01 12:00:00'),
+    (4, 'diana_updated', 'diana.new@example.com', 32, TIMESTAMP '2024-02-02 15:00:00');
+
+-- Query again to see updates
+SELECT * FROM users ORDER BY user_id;
+
+-- Count records
+SELECT COUNT(*) as total_users FROM users;
+
+-- Filter query
+SELECT * FROM users WHERE age > 30;

--- a/verify_test.py
+++ b/verify_test.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+import json
+import subprocess
+import time
+
+def run_command(cmd):
+    """Run a command and return output"""
+    result = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    return result.stdout
+
+def main():
+    print("=" * 60)
+    print("APACHE FLINK + PAIMON TEST VERIFICATION")
+    print("=" * 60)
+
+    # Check Docker containers
+    print("\n1. Docker Containers Status:")
+    print("-" * 40)
+    containers = run_command("docker compose ps --format json")
+    for line in containers.strip().split('\n'):
+        if line:
+            container = json.loads(line)
+            print(f"  ✓ {container['Name']}: {container['Status']}")
+
+    # Check Flink cluster status
+    print("\n2. Flink Cluster Status:")
+    print("-" * 40)
+    cluster_info = run_command("curl -s http://localhost:8081/overview")
+    if cluster_info:
+        overview = json.loads(cluster_info)
+        print(f"  ✓ Flink Version: {overview.get('flink-version', 'N/A')}")
+        print(f"  ✓ Task Managers: {overview.get('taskmanagers', 0)}")
+        print(f"  ✓ Task Slots: {overview.get('slots-total', 0)} total, {overview.get('slots-available', 0)} available")
+
+    # Check completed jobs
+    print("\n3. Flink Jobs:")
+    print("-" * 40)
+    jobs_info = run_command("curl -s http://localhost:8081/jobs")
+    if jobs_info:
+        jobs = json.loads(jobs_info)
+        for job in jobs.get('jobs', []):
+            print(f"  ✓ Job {job['id'][:8]}... - Status: {job['status']}")
+
+    # Check MinIO data
+    print("\n4. MinIO Storage Verification:")
+    print("-" * 40)
+
+    # Check warehouse structure
+    warehouse = run_command("docker exec minio sh -c 'mc ls local/warehouse/' 2>/dev/null")
+    if "test_db.db" in warehouse:
+        print("  ✓ Database 'test_db.db' exists in warehouse")
+
+    # Check table structure
+    table_dirs = run_command("docker exec minio sh -c 'mc ls local/warehouse/test_db.db/users/' 2>/dev/null")
+    expected_dirs = ['bucket-', 'manifest/', 'schema/', 'snapshot/']
+    for expected in expected_dirs:
+        if any(expected in line for line in table_dirs.split('\n')):
+            print(f"  ✓ Table structure contains: {expected.rstrip('/')}")
+
+    # Count data files
+    data_files = run_command("docker exec minio sh -c 'mc ls --recursive local/warehouse/test_db.db/users/ 2>/dev/null' | grep -c 'data-' || echo 0")
+    print(f"  ✓ Data files found: {data_files.strip()}")
+
+    # Check snapshots
+    snapshots = run_command("docker exec minio sh -c 'mc ls local/warehouse/test_db.db/users/snapshot/ 2>/dev/null'")
+    snapshot_count = len([l for l in snapshots.split('\n') if 'snapshot-' in l])
+    print(f"  ✓ Snapshots created: {snapshot_count}")
+
+    print("\n5. Test Summary:")
+    print("-" * 40)
+    print("  ✓ Flink cluster is running")
+    print("  ✓ Paimon catalog created successfully")
+    print("  ✓ Data successfully written to MinIO S3 storage")
+    print("  ✓ Paimon table structure properly initialized")
+    print("  ✓ Multiple snapshots indicate successful data operations")
+
+    print("\n✅ ALL TESTS PASSED - Flink + Paimon integration is working!")
+    print("=" * 60)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #4.

The SQL walkthrough, the verification script, and the setup notes were untracked, so a fresh clone only had the Docker files and not the runnable demo. This adds those files to git along with the project guidance, and adds a .gitignore that excludes local-only `.claude`, editor, and Python cache state.

After this change the working tree is clean and a fresh clone contains everything needed for the documented quick start.