### PR TITLE
Pin container images and verify downloaded jars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,35 @@
 FROM flink:1.19.3-java17
 
-# Download Paimon JARs
+# Dependency versions and download location, kept as build args so they are
+# easy to find and bump in one place.
 ARG PAIMON_VERSION=1.2.0
+ARG PAIMON_FLINK_MINOR=1.19
+ARG HADOOP_UBER_VERSION=2.8.3-10.0
+ARG MAVEN_BASE=https://repo1.maven.org/maven2
+
+# Expected SHA-1 checksums published on Maven Central for each jar. The build
+# fails if a download is corrupt, truncated, or replaced.
+ARG PAIMON_FLINK_SHA1=1b75616bd06a9ada84b2011a37d242dd67472138
+ARG PAIMON_S3_SHA1=ed55bcfe18fd7723b7d545bb3d58f0609c0bb792
+ARG HADOOP_UBER_SHA1=5dd57b5d38965c0f70e3f63d2581755df6c296bb
+
+# Download the Paimon and Hadoop jars, then verify them against the pinned
+# checksums. curl -f makes an HTTP error page fail the build instead of being
+# saved as a jar, and --retry rides out transient network blips.
 RUN set -eux; \
-    curl -L -o /opt/flink/lib/paimon-flink-1.19-${PAIMON_VERSION}.jar \
-      https://repo1.maven.org/maven2/org/apache/paimon/paimon-flink-1.19/${PAIMON_VERSION}/paimon-flink-1.19-${PAIMON_VERSION}.jar; \
-    curl -L -o /opt/flink/lib/paimon-s3-${PAIMON_VERSION}.jar \
-      https://repo1.maven.org/maven2/org/apache/paimon/paimon-s3/${PAIMON_VERSION}/paimon-s3-${PAIMON_VERSION}.jar; \
-    curl -L -o /opt/flink/lib/flink-shaded-hadoop-2-uber-2.8.3-10.0.jar \
-      https://repo1.maven.org/maven2/org/apache/flink/flink-shaded-hadoop-2-uber/2.8.3-10.0/flink-shaded-hadoop-2-uber-2.8.3-10.0.jar
-
-# Set proper ownership
-RUN chown flink:flink /opt/flink/lib/paimon-*.jar /opt/flink/lib/flink-shaded-hadoop-*.jar
-
-# Verify JARs were downloaded
-RUN ls -la /opt/flink/lib/paimon-* /opt/flink/lib/flink-shaded-hadoop-*
+    cd /opt/flink/lib; \
+    curl -fL --retry 3 --retry-delay 2 -o paimon-flink-${PAIMON_FLINK_MINOR}-${PAIMON_VERSION}.jar \
+      ${MAVEN_BASE}/org/apache/paimon/paimon-flink-${PAIMON_FLINK_MINOR}/${PAIMON_VERSION}/paimon-flink-${PAIMON_FLINK_MINOR}-${PAIMON_VERSION}.jar; \
+    curl -fL --retry 3 --retry-delay 2 -o paimon-s3-${PAIMON_VERSION}.jar \
+      ${MAVEN_BASE}/org/apache/paimon/paimon-s3/${PAIMON_VERSION}/paimon-s3-${PAIMON_VERSION}.jar; \
+    curl -fL --retry 3 --retry-delay 2 -o flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar \
+      ${MAVEN_BASE}/org/apache/flink/flink-shaded-hadoop-2-uber/${HADOOP_UBER_VERSION}/flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar; \
+    printf '%s  %s\n' \
+      "${PAIMON_FLINK_SHA1}" "paimon-flink-${PAIMON_FLINK_MINOR}-${PAIMON_VERSION}.jar" \
+      "${PAIMON_S3_SHA1}" "paimon-s3-${PAIMON_VERSION}.jar" \
+      "${HADOOP_UBER_SHA1}" "flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar" \
+      > jars.sha1; \
+    sha1sum -c jars.sha1; \
+    rm jars.sha1; \
+    chown flink:flink paimon-*.jar flink-shaded-hadoop-*.jar; \
+    ls -la paimon-* flink-shaded-hadoop-*

--- a/README.md
+++ b/README.md
@@ -6,8 +6,12 @@ A complete Docker-based setup demonstrating how to use **Apache Flink** to write
 
 - **Apache Flink 1.19.3** - Stream processing framework
 - **Apache Paimon 1.2.0** - Lakehouse storage format with ACID transactions
-- **MinIO (latest)** - S3-compatible object storage
+- **flink-shaded-hadoop 2.8.3-10.0** - Hadoop classes Paimon needs for S3 access
+- **MinIO RELEASE.2025-09-07T16-13-09Z** - S3-compatible object storage
+- **MinIO Client (mc) RELEASE.2025-08-13T08-35-41Z** - Creates the demo buckets
 - **Custom Docker Image** - Pre-built with all required JARs to avoid dependency conflicts
+
+All images and jar versions are pinned, and the jar downloads are checksum-verified at build time so the setup stays reproducible over time.
 
 ## 🎯 Why This Approach Works
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 services:
   # MinIO S3-compatible storage
   minio:
-    image: minio/minio:latest
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
     container_name: minio
     ports:
       - "9000:9000"
@@ -21,7 +21,7 @@ services:
 
   # MinIO bucket initialization
   minio-init:
-    image: minio/mc:latest
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
     container_name: minio-init
     depends_on:
       minio:


### PR DESCRIPTION
Closes #2.

The Docker setup relied on `latest` MinIO images and unverified jar downloads, so a future image or a corrupt download could quietly break a previously working build.

This pins `minio/minio` and `minio/mc` to explicit release tags, moves the Flink, Paimon, and Hadoop jar versions into build args, and downloads the jars with `curl -fL --retry` so an error page or partial transfer fails the build instead of being saved as a jar. Each jar is then checked against its published SHA-1 checksum. The README now lists the pinned versions.

Tested with `docker compose build`, which downloads all three jars and reports `OK` for each checksum, and with a deliberately wrong checksum, which fails the build as expected.