### PR TITLE
Tighten Docker Compose startup and naming

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,16 @@
+# Copy this file to .env to override the local demo defaults.
+# docker compose reads .env automatically; without it the values below apply.
+
+# MinIO root credentials used by MinIO, the bucket init step, and the SQL demo.
+MINIO_ROOT_USER=admin
+MINIO_ROOT_PASSWORD=password123
+
+# Local name for the custom Flink image built from the Dockerfile.
+FLINK_IMAGE=flink-paimon:local
+
+# Container names. Override these when running more than one clone or
+# Compose project on the same machine to avoid collisions.
+MINIO_CONTAINER=minio
+MINIO_INIT_CONTAINER=minio-init
+FLINK_JOBMANAGER_CONTAINER=flink-jobmanager
+FLINK_TASKMANAGER_CONTAINER=flink-taskmanager

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 .idea/
 .vscode/
 
+# Local environment overrides (keep .env.example tracked)
+.env
+
 # Python
 __pycache__/
 *.pyc

--- a/README.md
+++ b/README.md
@@ -131,8 +131,9 @@ docker compose down -v
 ## 📝 Notes
 
 - This is an updated version of a project I originally started two years ago
-- MinIO credentials are `admin` / `password123` for local development
-- The setup automatically creates the required buckets (`warehouse` and `checkpoints`)
+- MinIO credentials default to `admin` / `password123`; copy `.env.example` to `.env` to change them or the container names
+- The custom Flink image is built locally as `flink-paimon:local`
+- Bucket creation runs to completion before Flink starts, so the `warehouse` and `checkpoints` buckets always exist first
 - All data is persisted in Docker volumes between restarts
 
 ## 🎉 Success

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
-
 services:
   # MinIO S3-compatible storage
   minio:
     image: minio/minio:RELEASE.2025-09-07T16-13-09Z
-    container_name: minio
+    container_name: ${MINIO_CONTAINER:-minio}
     ports:
       - "9000:9000"
       - "9001:9001"
     environment:
-      MINIO_ROOT_USER: admin
-      MINIO_ROOT_PASSWORD: password123
+      MINIO_ROOT_USER: ${MINIO_ROOT_USER:-admin}
+      MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-password123}
     command: server /data --console-address ":9001"
     volumes:
       - minio_data:/data
@@ -19,16 +18,17 @@ services:
       timeout: 20s
       retries: 3
 
-  # MinIO bucket initialization
+  # MinIO bucket initialization. Runs once and exits; Flink waits for it to
+  # finish so the warehouse and checkpoints buckets always exist first.
   minio-init:
     image: minio/mc:RELEASE.2025-08-13T08-35-41Z
-    container_name: minio-init
+    container_name: ${MINIO_INIT_CONTAINER:-minio-init}
     depends_on:
       minio:
         condition: service_healthy
     entrypoint: >
       /bin/sh -c "
-      /usr/bin/mc alias set minio http://minio:9000 admin password123;
+      /usr/bin/mc alias set minio http://minio:9000 ${MINIO_ROOT_USER:-admin} ${MINIO_ROOT_PASSWORD:-password123};
       /usr/bin/mc mb --ignore-existing minio/warehouse;
       /usr/bin/mc mb --ignore-existing minio/checkpoints;
       echo 'MinIO buckets created successfully';
@@ -37,7 +37,8 @@ services:
   # Flink Job Manager with custom image
   jobmanager:
     build: .
-    container_name: flink-jobmanager
+    image: ${FLINK_IMAGE:-flink-paimon:local}
+    container_name: ${FLINK_JOBMANAGER_CONTAINER:-flink-jobmanager}
     ports:
       - "8081:8081"
     environment:
@@ -47,7 +48,8 @@ services:
       - ./conf/flink-conf.yaml:/opt/flink/conf/flink-conf.yaml
     command: jobmanager
     depends_on:
-      - minio-init
+      minio-init:
+        condition: service_completed_successfully
     healthcheck:
       test: ["CMD-SHELL", "curl -f http://localhost:8081/ || exit 1"]
       interval: 30s
@@ -57,7 +59,8 @@ services:
   # Flink Task Manager
   taskmanager:
     build: .
-    container_name: flink-taskmanager
+    image: ${FLINK_IMAGE:-flink-paimon:local}
+    container_name: ${FLINK_TASKMANAGER_CONTAINER:-flink-taskmanager}
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
       - TASK_MANAGER_NUMBER_OF_TASK_SLOTS=4
@@ -67,12 +70,7 @@ services:
     depends_on:
       jobmanager:
         condition: service_healthy
-    scale: 1
 
 volumes:
   minio_data:
     driver: local
-
-networks:
-  default:
-    name: flink-paimon-network


### PR DESCRIPTION
Closes #6.

The Compose file worked for a local proof but had a few rough edges. Flink only waited for the bucket init container to start, container names were fixed, the built image was unnamed, and credentials were hard-coded.

Changes:

- Flink waits for `minio-init` with `service_completed_successfully`, so the `warehouse` and `checkpoints` buckets always exist before Flink uses them.
- The custom image is named `flink-paimon:local`.
- Container names and MinIO credentials come from environment variables with the existing defaults, documented in `.env.example` (and `.env` is gitignored).
- The fixed network name is dropped so Compose namespaces the network per project, reducing collisions when running more than one clone.

Tested with `docker compose up -d --build`: minio becomes healthy, the init container creates both buckets and exits 0, and only then does Flink start and become healthy. The smoke test still recognizes the default container names, and overriding the container-name variables renames them as expected.