### PR TITLE
Add richer Paimon SQL examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ The cluster is configured in `conf/flink-conf.yaml`. The settings that matter fo
 
 The memory sizes, web submit/cancel, restart strategy, and hard-coded MinIO credentials are local demo choices and should be reviewed before reusing this file elsewhere.
 
+## 📚 Example SQL Walkthroughs
+
+The `sql/` directory holds focused examples that show more of what Paimon can do beyond a basic insert. They are mounted into the JobManager at `/sql` and use their own `paimon_examples` database, so they stay separate from the main `test_db` demo. Each one drops and recreates its table, so it produces the same result every run.
+
+Run any of them after `docker compose up -d`:
+
+```bash
+docker exec -i flink-jobmanager /opt/flink/bin/sql-client.sh -f /sql/example_upserts.sql
+```
+
+- `example_upserts.sql` - primary-key upserts, where rewriting a key updates the row instead of adding a duplicate
+- `example_history.sql` - inspecting snapshot and schema history through Paimon's system tables
+- `example_schema_evolution.sql` - adding a column to a live table, with older rows reading back as NULL
+- `example_time_travel.sql` - reading an earlier snapshot with a query hint and comparing it to the current table
+
+The smoke test (`verify_test.py`) covers the canonical `test_db.users` demo from the quick start.
+
 ## 🧹 Cleanup
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,8 +44,9 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
     volumes:
-      # Only mount configuration, no JARs needed
+      # Mount the config and the SQL examples (read-only) for the sql-client
       - ./conf/flink-conf.yaml:/opt/flink/conf/flink-conf.yaml
+      - ./sql:/sql:ro
     command: jobmanager
     depends_on:
       minio-init:

--- a/sql/example_history.sql
+++ b/sql/example_history.sql
@@ -1,0 +1,39 @@
+-- Snapshot and schema history: every commit creates a new snapshot, and Paimon
+-- exposes that history through system tables you can query directly. Run with:
+--   docker exec -i flink-jobmanager /opt/flink/bin/sql-client.sh -f /sql/example_history.sql
+SET 'execution.runtime-mode' = 'batch';
+-- Wait for each INSERT job to finish before the next statement reads the table
+SET 'table.dml-sync' = 'true';
+
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+USE CATALOG paimon_catalog;
+CREATE DATABASE IF NOT EXISTS paimon_examples;
+USE paimon_examples;
+
+-- Start from a clean table so the example is the same every run
+DROP TABLE IF EXISTS inventory;
+
+CREATE TABLE IF NOT EXISTS inventory (
+    sku STRING,
+    quantity INT,
+    PRIMARY KEY (sku) NOT ENFORCED
+) WITH ('bucket' = '2');
+
+-- Two separate commits produce two snapshots
+INSERT INTO inventory VALUES ('A-100', 5), ('A-200', 12);
+INSERT INTO inventory VALUES ('A-100', 8), ('A-300', 3);
+
+SET 'sql-client.execution.result-mode' = 'tableau';
+-- One row per commit
+SELECT snapshot_id, schema_id, commit_kind, total_record_count
+FROM inventory$snapshots ORDER BY snapshot_id;
+
+-- The table schema as Paimon tracks it
+SELECT schema_id, fields FROM inventory$schemas ORDER BY schema_id;

--- a/sql/example_schema_evolution.sql
+++ b/sql/example_schema_evolution.sql
@@ -1,0 +1,41 @@
+-- Schema evolution: add a column to an existing table without rewriting old
+-- data. Rows written before the change read back with NULL for the new column.
+-- Run with:
+--   docker exec -i flink-jobmanager /opt/flink/bin/sql-client.sh -f /sql/example_schema_evolution.sql
+SET 'execution.runtime-mode' = 'batch';
+-- Wait for each INSERT job to finish before the next statement reads the table
+SET 'table.dml-sync' = 'true';
+
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+USE CATALOG paimon_catalog;
+CREATE DATABASE IF NOT EXISTS paimon_examples;
+USE paimon_examples;
+
+-- Start from a clean table so the example is the same every run
+DROP TABLE IF EXISTS customers;
+
+CREATE TABLE IF NOT EXISTS customers (
+    customer_id INT,
+    name STRING,
+    PRIMARY KEY (customer_id) NOT ENFORCED
+) WITH ('bucket' = '2');
+
+-- Written under the original two-column schema
+INSERT INTO customers VALUES (1, 'Ada'), (2, 'Linus');
+
+-- Add a column; existing rows are not rewritten
+ALTER TABLE customers ADD (country STRING);
+
+-- New row carries the added column
+INSERT INTO customers (customer_id, name, country) VALUES (3, 'Grace', 'US');
+
+SET 'sql-client.execution.result-mode' = 'tableau';
+-- Rows 1 and 2 show NULL country, row 3 shows 'US'
+SELECT * FROM customers ORDER BY customer_id;

--- a/sql/example_time_travel.sql
+++ b/sql/example_time_travel.sql
@@ -1,0 +1,39 @@
+-- Time travel: read the table as it looked at an earlier snapshot using a query
+-- hint, then compare with the current state. Run with:
+--   docker exec -i flink-jobmanager /opt/flink/bin/sql-client.sh -f /sql/example_time_travel.sql
+SET 'execution.runtime-mode' = 'batch';
+-- Wait for each INSERT job to finish before the next statement reads the table
+SET 'table.dml-sync' = 'true';
+
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+USE CATALOG paimon_catalog;
+CREATE DATABASE IF NOT EXISTS paimon_examples;
+USE paimon_examples;
+
+-- Start from a clean table so the example is the same every run
+DROP TABLE IF EXISTS metrics;
+
+CREATE TABLE IF NOT EXISTS metrics (
+    name STRING,
+    metric_value INT,
+    PRIMARY KEY (name) NOT ENFORCED
+) WITH ('bucket' = '1');
+
+-- Snapshot 1
+INSERT INTO metrics VALUES ('signups', 10);
+-- Snapshot 2
+INSERT INTO metrics VALUES ('signups', 25), ('logins', 40);
+
+SET 'sql-client.execution.result-mode' = 'tableau';
+-- The table as of the first snapshot: only signups = 10
+SELECT * FROM metrics /*+ OPTIONS('scan.snapshot-id' = '1') */ ORDER BY name;
+
+-- The current table
+SELECT * FROM metrics ORDER BY name;

--- a/sql/example_upserts.sql
+++ b/sql/example_upserts.sql
@@ -1,0 +1,42 @@
+-- Primary-key upserts: writing a row with an existing key updates it in place
+-- rather than appending a duplicate. Run after `docker compose up -d`:
+--   docker exec -i flink-jobmanager /opt/flink/bin/sql-client.sh -f /sql/example_upserts.sql
+SET 'execution.runtime-mode' = 'batch';
+-- Wait for each INSERT job to finish before the next statement reads the table
+SET 'table.dml-sync' = 'true';
+
+CREATE CATALOG paimon_catalog WITH (
+    'type' = 'paimon',
+    'warehouse' = 's3://warehouse/',
+    's3.endpoint' = 'http://minio:9000',
+    's3.access-key' = 'admin',
+    's3.secret-key' = 'password123',
+    's3.path.style.access' = 'true'
+);
+USE CATALOG paimon_catalog;
+CREATE DATABASE IF NOT EXISTS paimon_examples;
+USE paimon_examples;
+
+-- Start from a clean table so the example is the same every run
+DROP TABLE IF EXISTS products;
+
+CREATE TABLE IF NOT EXISTS products (
+    product_id INT,
+    name STRING,
+    price DECIMAL(10, 2),
+    PRIMARY KEY (product_id) NOT ENFORCED
+) WITH ('bucket' = '2');
+
+-- First write
+INSERT INTO products VALUES
+    (1, 'Keyboard', 49.99),
+    (2, 'Mouse', 19.99);
+
+-- Re-writing key 1 updates it; key 3 is a new row
+INSERT INTO products VALUES
+    (1, 'Mechanical Keyboard', 89.99),
+    (3, 'Monitor', 199.00);
+
+SET 'sql-client.execution.result-mode' = 'tableau';
+-- Three rows: product 1 shows the updated name and price, not a duplicate
+SELECT * FROM products ORDER BY product_id;


### PR DESCRIPTION
Closes #7.

The demo proved Flink could write a Paimon table to MinIO but did not show much of what makes Paimon interesting. This adds four small, self-contained SQL examples under `sql/`:

- `example_upserts.sql` - primary-key upserts (rewriting a key updates the row)
- `example_history.sql` - snapshot and schema history via Paimon system tables
- `example_schema_evolution.sql` - adding a column to a live table, old rows read back NULL
- `example_time_travel.sql` - reading an earlier snapshot with a query hint

Each runs in batch mode with `table.dml-sync` so a single `sql-client -f` run returns consistent results, and each drops and recreates its own table in a separate `paimon_examples` database so it behaves the same on every run and never touches the canonical `test_db` demo. The `sql/` directory is mounted into the JobManager at `/sql`, and the README explains each example. The existing smoke test still covers the canonical `test_db.users` demo.

Tested against a live stack: all four run cleanly twice in a row, showing the updated upsert row, two snapshots in the history table, NULLs for pre-evolution rows, and the earlier snapshot via time travel.