### PR TITLE
Update to Flink 1.20.4 and Paimon 1.4.1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,12 +20,12 @@ The project is intentionally lightweight. Prefer small, practical changes that m
 
 The current checked-in Dockerfile uses:
 
-- Apache Flink `1.19.3`
-- Apache Paimon `1.2.0`
+- Apache Flink `1.20.4`
+- Apache Paimon `1.4.1` (`paimon-flink-1.20` jar)
 - Java 17 Flink base image
-- MinIO images currently referenced as `latest`
+- Pinned MinIO and MinIO client images
 
-As of June 2026, this should be revisited. Paimon `1.4.1` publishes bundled jars for Flink `2.2`, `2.1`, `2.0`, `1.20`, `1.19`, and older lines. A conservative refresh path is likely Flink `1.20.4` with Paimon `1.4.1`; a more modern path is Flink `2.2.x` with Paimon `1.4.1`.
+This is the conservative lane: it stays on the Flink 1.x line while moving Paimon to a current release. The modern lane is Flink `2.2.x` with Paimon `1.4.1`; moving there means bumping the base image, setting `PAIMON_FLINK_MINOR` to the matching Flink minor, and revisiting the config and SQL for any 2.x changes. Note Flink 1.20 still reads the legacy `flink-conf.yaml`, while `config.yaml` is the newer format to migrate to later.
 
 When changing versions, keep the Flink image, Paimon jar artifact name, Paimon version, and README in sync.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
-FROM flink:1.19.3-java17
+FROM flink:1.20.4-java17
 
 # Dependency versions and download location, kept as build args so they are
-# easy to find and bump in one place.
-ARG PAIMON_VERSION=1.2.0
-ARG PAIMON_FLINK_MINOR=1.19
+# easy to find and bump in one place. PAIMON_FLINK_MINOR must match the Flink
+# minor version of the base image above.
+ARG PAIMON_VERSION=1.4.1
+ARG PAIMON_FLINK_MINOR=1.20
 ARG HADOOP_UBER_VERSION=2.8.3-10.0
 ARG MAVEN_BASE=https://repo1.maven.org/maven2
 
 # Expected SHA-1 checksums published on Maven Central for each jar. The build
 # fails if a download is corrupt, truncated, or replaced.
-ARG PAIMON_FLINK_SHA1=1b75616bd06a9ada84b2011a37d242dd67472138
-ARG PAIMON_S3_SHA1=ed55bcfe18fd7723b7d545bb3d58f0609c0bb792
+ARG PAIMON_FLINK_SHA1=951adaacf361b3d2e22ef7077019d0522527c2b1
+ARG PAIMON_S3_SHA1=58068d37c72d5ddbb56cdbd48db69f9467bda5c5
 ARG HADOOP_UBER_SHA1=5dd57b5d38965c0f70e3f63d2581755df6c296bb
 
 # Download the Paimon and Hadoop jars, then verify them against the pinned

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ A complete Docker-based setup demonstrating how to use **Apache Flink** to write
 
 ## 🚀 What's Inside
 
-- **Apache Flink 1.19.3** - Stream processing framework
-- **Apache Paimon 1.2.0** - Lakehouse storage format with ACID transactions
+- **Apache Flink 1.20.4** - Stream processing framework
+- **Apache Paimon 1.4.1** - Lakehouse storage format with ACID transactions
 - **flink-shaded-hadoop 2.8.3-10.0** - Hadoop classes Paimon needs for S3 access
 - **MinIO RELEASE.2025-09-07T16-13-09Z** - S3-compatible object storage
 - **MinIO Client (mc) RELEASE.2025-08-13T08-35-41Z** - Creates the demo buckets
@@ -13,12 +13,16 @@ A complete Docker-based setup demonstrating how to use **Apache Flink** to write
 
 All images and jar versions are pinned, and the jar downloads are checksum-verified at build time so the setup stays reproducible over time.
 
+### Version lane
+
+This demo runs the conservative lane: Flink 1.20.4 with Paimon 1.4.1. It stays close to the long-lived Flink 1.x line while moving Paimon up to a current release, so the upgrade from the original 1.19.3 / 1.2.0 setup is low risk. To move to the modern lane (Flink 2.2.x with Paimon 1.4.1), bump the base image and set `PAIMON_FLINK_MINOR` to the matching Flink minor in the Dockerfile; expect to revisit the config and SQL for any 2.x changes. Flink 1.20 reads the legacy `flink-conf.yaml` used here, though `config.yaml` is the newer format to migrate to later.
+
 ## 🎯 Why This Approach Works
 
-Previous attempts to use volume mounts for JARs often failed due to classpath and dependency resolution issues. This project builds a custom Dockerfile that extends `flink:1.19.3-java17` and downloads three critical JARs directly into `/opt/flink/lib/`:
+Previous attempts to use volume mounts for JARs often failed due to classpath and dependency resolution issues. This project builds a custom Dockerfile that extends `flink:1.20.4-java17` and downloads three critical JARs directly into `/opt/flink/lib/`:
 
-- `paimon-flink-1.19-1.2.0.jar` - Main Paimon connector for Flink
-- `paimon-s3-1.2.0.jar` - Paimon's S3 implementation
+- `paimon-flink-1.20-1.4.1.jar` - Main Paimon connector for Flink
+- `paimon-s3-1.4.1.jar` - Paimon's S3 implementation
 - `flink-shaded-hadoop-2-uber-2.8.3-10.0.jar` - Required Hadoop classes
 
 **The key insight:** Paimon internally requires Hadoop classes regardless of which S3 approach you use, but Flink's base images don't include them. The custom Docker image ensures all dependencies are available in a single, consistent environment - eliminating the dependency hell that plagued earlier versions of this integration.

--- a/sql/batch_query.sql
+++ b/sql/batch_query.sql
@@ -12,7 +12,7 @@ USE CATALOG paimon_catalog;
 USE test_db;
 
 -- Set execution mode to batch for query
-SET execution.runtime-mode=batch;
+SET 'execution.runtime-mode' = 'batch';
 
 -- Create a sink table to output results
 CREATE TEMPORARY TABLE print_sink (

--- a/sql/query_users.sql
+++ b/sql/query_users.sql
@@ -13,7 +13,7 @@ USE CATALOG paimon_catalog;
 USE test_db;
 
 -- Set result mode for queries
-SET sql-client.execution.result-mode=TABLEAU;
+SET 'sql-client.execution.result-mode' = 'TABLEAU';
 
 -- Query all users
 SELECT * FROM users;

--- a/sql/test_paimon.sql
+++ b/sql/test_paimon.sql
@@ -37,7 +37,7 @@ INSERT INTO users VALUES
     (5, 'edward', 'edward@example.com', 26, TIMESTAMP '2024-01-19 16:30:00');
 
 -- Set result mode for queries
-SET sql-client.execution.result-mode=TABLEAU;
+SET 'sql-client.execution.result-mode' = 'TABLEAU';
 
 -- Query the data
 SELECT * FROM users;


### PR DESCRIPTION
Closes #3.

The demo was pinned to Flink 1.19.3 and Paimon 1.2.0. This moves it onto the conservative upgrade lane the issue recommends: Flink 1.20.4 with Paimon 1.4.1, staying on the Flink 1.x line while bringing Paimon to a current release.

Changes:

- Base image to `flink:1.20.4-java17`, and the Dockerfile now downloads `paimon-flink-1.20-1.4.1.jar` and `paimon-s3-1.4.1.jar` with updated SHA-1 checksums.
- Flink 1.20 only accepts the quoted `SET` syntax, so `sql/test_paimon.sql`, `sql/batch_query.sql`, and `sql/query_users.sql` are updated from the old unquoted form (otherwise they fail to parse).
- README and CLAUDE.md document the chosen versions and the tradeoff against the modern Flink 2.x lane, and note that Flink 1.20 still reads the legacy `flink-conf.yaml`.

Tested with a full `docker compose build` and `up`: the image builds and checksums pass, the cluster comes up healthy with the mounted config applied (4 slots), the canonical demo writes succeed, the smoke test passes (4 data files, 2 snapshots), and `sql/batch_query.sql` reads the data back with the quoted SET.