### PR TITLE
Refresh stale internal docs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,9 +12,10 @@ The project is intentionally lightweight. Prefer small, practical changes that m
 - `docker-compose.yml`: Starts MinIO, creates buckets, and runs Flink JobManager and TaskManager.
 - `conf/flink-conf.yaml`: Local Flink cluster configuration.
 - `README.md`: User-facing quick start and project explanation.
-- `FLINK_PAIMON_SETUP.md`: Setup notes and troubleshooting guidance. This file is currently untracked unless committed later.
-- `sql/`: SQL walkthrough files for creating/querying Paimon tables. This directory is currently untracked unless committed later.
-- `verify_test.py`: Local verification script. This file is currently untracked unless committed later.
+- `FLINK_PAIMON_SETUP.md`: Setup notes and troubleshooting guidance.
+- `sql/`: SQL walkthrough files for creating/querying Paimon tables, including the canonical `test_paimon.sql` and the focused `example_*.sql` demos.
+- `verify_test.py`: Smoke test that fails with a non-zero exit code unless the stack is healthy and the demo has written Paimon data.
+- `.env.example`: Documents the MinIO credentials and container-name overrides read by Compose.
 
 ## Current Dependency Context
 
@@ -77,26 +78,26 @@ docker compose down -v
 
 ## Development Guidance
 
-- Keep the README, SQL scripts, verifier, and MinIO warehouse paths aligned. The README currently describes a `user_events` example, while local SQL files use a `users` table.
+- Keep the README, SQL scripts, verifier, and MinIO warehouse paths aligned. The canonical demo is `test_db.users` under `s3://warehouse/`, matching `sql/test_paimon.sql`, the README quick start, and `verify_test.py`.
 - Prefer one canonical demo path and make all documentation and tests point to it.
 - Pin container images instead of using `latest`.
 - Make jar downloads fail fast and verify downloaded artifacts where practical.
-- Treat `verify_test.py` as needing improvement: it should fail with a non-zero exit code when Flink, MinIO, the expected table, data files, or snapshots are missing.
+- Keep `verify_test.py` a real smoke test: it must exit non-zero when Flink, MinIO, the expected table, data files, or snapshots are missing.
 - Avoid committing local assistant/editor state such as `.claude/settings.local.json`.
 - Be careful with Docker volume cleanup. `docker compose down -v` deletes local MinIO data.
 
-## Open Cleanup Themes
+## Cleanup Status
 
-The repo has GitHub issues tracking the main cleanup work:
+The initial cleanup round is complete:
 
-- Pin container images and verify downloaded jars.
-- Update the Flink and Paimon dependency strategy.
-- Commit intended demo SQL files and the verifier, and ignore local settings.
-- Make README and SQL scripts describe the same demo.
-- Tighten Docker Compose startup dependencies and naming.
-- Add richer Paimon examples beyond a basic insert.
-- Replace `verify_test.py` with a real failing smoke test.
-- Document and tune the Flink configuration for the local demo.
+- Container images are pinned and downloaded jars are checksum-verified.
+- The dependency strategy is documented (conservative lane: Flink 1.20.4, Paimon 1.4.1).
+- The demo SQL files and the verifier are tracked, and local settings are ignored.
+- The README and SQL scripts describe the same canonical demo.
+- Docker Compose startup waits for bucket creation and uses overridable names.
+- Richer Paimon examples cover upserts, history, schema evolution, and time travel.
+- `verify_test.py` is a real smoke test that exits non-zero on failure.
+- The Flink configuration is documented and tuned, with checkpoints written to MinIO.
 
 ## Expected Demo Shape
 

--- a/FLINK_PAIMON_SETUP.md
+++ b/FLINK_PAIMON_SETUP.md
@@ -30,9 +30,9 @@ CREATE CATALOG paimon_catalog WITH (
 - **Fix**: Ensure warehouse path has trailing slash: `'warehouse' = 's3://warehouse/'`
 
 #### SQL Client Execution Mode
-- **Issue**: Queries fail in non-interactive mode
-- **Fix**: For batch queries, use `SET execution.runtime-mode=batch;`
-- **Note**: SET commands don't work in `-f` file mode with certain Flink versions
+- **Issue**: Queries fail or hang in non-interactive (`-f`) mode
+- **Fix**: For batch queries, use the quoted form `SET 'execution.runtime-mode' = 'batch';`. Flink 1.20 rejects the older unquoted `SET key=value;` syntax.
+- **Note**: Add `SET 'table.dml-sync' = 'true';` so each INSERT finishes before the next statement reads the table in `-f` mode
 
 ### 4. Testing Data Flow
 
@@ -52,19 +52,23 @@ CREATE TABLE users (
 ```
 
 #### Verify Data in MinIO
+MinIO stores each object on its single drive under `/data`, so the table layout
+can be inspected directly without configuring an `mc` alias:
 ```bash
 # Check warehouse structure
-docker exec minio mc ls local/warehouse/test_db.db/users/
+docker exec minio ls /data/warehouse/test_db.db/users/
 
 # Expected directories:
-# - bucket-0/ bucket-1/ bucket-2/  (data buckets)
+# - bucket-0/ bucket-1/ ...  (data buckets)
 # - manifest/  (table manifests)
 # - schema/    (table schema)
 # - snapshot/  (data snapshots)
 
-# Count data files
-docker exec minio sh -c "mc ls --recursive local/warehouse/test_db.db/users/ | grep -c 'data-'"
+# List the data files across buckets
+docker exec minio sh -c "ls -1R /data/warehouse/test_db.db/users/ | grep 'data-'"
 ```
+Or just run `python3 verify_test.py`, which checks all of this and exits
+non-zero if anything is missing.
 
 ### 5. Verification Checklist
 - [ ] All containers running and healthy: `docker compose ps`
@@ -76,8 +80,8 @@ docker exec minio sh -c "mc ls --recursive local/warehouse/test_db.db/users/ | g
 - [ ] Multiple snapshots created after inserts/updates
 
 ### 6. Key Dependencies
-- **Flink**: 1.19.3 (or compatible version)
-- **Paimon**: 1.2.0 (must match Flink version compatibility)
+- **Flink**: 1.20.4 (conservative lane; see README for the modern Flink 2.x option)
+- **Paimon**: 1.4.1 (`paimon-flink-1.20` jar must match the Flink minor version)
 - **Hadoop AWS**: Required for S3 filesystem support
 - **Dockerfile must include**: Paimon JARs in `/opt/flink/lib/`
 


### PR DESCRIPTION
Refreshes internal docs that had drifted out of date.

`FLINK_PAIMON_SETUP.md`:
- Key dependencies updated from Flink 1.19.3 / Paimon 1.2.0 to the current 1.20.4 / 1.4.1.
- SQL client note updated to the quoted `SET 'key' = 'value';` syntax Flink 1.20 requires, plus the `table.dml-sync` tip for `-f` runs.
- MinIO verification commands switched to a filesystem listing under `/data` that works without configuring an `mc` alias, and point to `verify_test.py`.

`CLAUDE.md`:
- Dropped the "currently untracked" notes for the SQL files and verifier, which are now tracked, and added `.env.example`.
- Removed the stale claim that the README uses a `user_events` table; the canonical demo is `test_db.users`.
- Reframed the cleanup list to reflect that the initial round is complete.

Docs-only change. Verified no stale version strings, `user_events`, or unquoted `SET` references remain in the tracked docs.
