### PR TITLE
Verify downloaded jars with SHA-512

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,11 +8,13 @@ ARG PAIMON_FLINK_MINOR=1.20
 ARG HADOOP_UBER_VERSION=2.8.3-10.0
 ARG MAVEN_BASE=https://repo1.maven.org/maven2
 
-# Expected SHA-1 checksums published on Maven Central for each jar. The build
-# fails if a download is corrupt, truncated, or replaced.
-ARG PAIMON_FLINK_SHA1=951adaacf361b3d2e22ef7077019d0522527c2b1
-ARG PAIMON_S3_SHA1=58068d37c72d5ddbb56cdbd48db69f9467bda5c5
-ARG HADOOP_UBER_SHA1=5dd57b5d38965c0f70e3f63d2581755df6c296bb
+# Expected SHA-512 checksums for each jar. The build fails if a download is
+# corrupt, truncated, or replaced. Maven Central does not publish .sha512 for
+# these artifacts, so the values are computed from the released jars (their
+# .sha1 checksums were cross-checked against Maven Central when recorded).
+ARG PAIMON_FLINK_SHA512=97b5b8dbff1c3ad44bae947fafc481e23378a053f730e83beba2320dc861633e62ee9d738bf1103497c89861a2b65a44779e91f0133819617916eb0261a8855a
+ARG PAIMON_S3_SHA512=b52b07409c8dca20b4e8484a252d8a167f38798b36125d4c4d8df6a50d61ca30b2818d2202b178ab534285fcdda165efa56b7c8c85134d0438cf6c08f7364c11
+ARG HADOOP_UBER_SHA512=c04d217fb53123054c58c5c492cc8d87e75aa72b798e3b4858757cb4d389ccd9866c224662a012e1e9b012c05e481372e2bbc97cd45746f924814733d864591f
 
 # Download the Paimon and Hadoop jars, then verify them against the pinned
 # checksums. curl -f makes an HTTP error page fail the build instead of being
@@ -26,12 +28,12 @@ RUN set -eux; \
     curl -fL --retry 3 --retry-delay 2 -o flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar \
       ${MAVEN_BASE}/org/apache/flink/flink-shaded-hadoop-2-uber/${HADOOP_UBER_VERSION}/flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar; \
     printf '%s  %s\n' \
-      "${PAIMON_FLINK_SHA1}" "paimon-flink-${PAIMON_FLINK_MINOR}-${PAIMON_VERSION}.jar" \
-      "${PAIMON_S3_SHA1}" "paimon-s3-${PAIMON_VERSION}.jar" \
-      "${HADOOP_UBER_SHA1}" "flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar" \
-      > jars.sha1; \
-    sha1sum -c jars.sha1; \
-    rm jars.sha1; \
+      "${PAIMON_FLINK_SHA512}" "paimon-flink-${PAIMON_FLINK_MINOR}-${PAIMON_VERSION}.jar" \
+      "${PAIMON_S3_SHA512}" "paimon-s3-${PAIMON_VERSION}.jar" \
+      "${HADOOP_UBER_SHA512}" "flink-shaded-hadoop-2-uber-${HADOOP_UBER_VERSION}.jar" \
+      > jars.sha512; \
+    sha512sum -c jars.sha512; \
+    rm jars.sha512; \
     chown flink:flink paimon-*.jar flink-shaded-hadoop-*.jar; \
     ls -la paimon-* flink-shaded-hadoop-*
 


### PR DESCRIPTION
Switches the Dockerfile jar integrity check from SHA-1 to SHA-512. SHA-1 is adequate for catching accidental corruption but is a weak hash; SHA-512 is a stronger check against a corrupt or tampered download.

Maven Central does not publish `.sha512` for these three artifacts (only `.sha1` and `.md5`), so the pinned SHA-512 values are computed from the released jars. Their `.sha1` checksums were cross-checked against Maven Central before recording, so the jars are the published releases.

Tested: `docker compose build` reports `OK` for all three jars under `sha512sum -c`, and a deliberately wrong SHA-512 makes the build fail at the verification step.
