### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  checks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate Docker Compose config
+        run: docker compose config -q
+      - name: Byte-compile the smoke test
+        run: python3 -m py_compile verify_test.py
+      - name: Check shell scripts parse
+        run: |
+          for f in $(git ls-files '*.sh'); do
+            echo "checking $f"
+            bash -n "$f"
+          done
+
+  # Full build-and-run smoke test. Pulls images and builds the custom Flink
+  # image, so it is gated behind manual dispatch rather than every push.
+  smoke:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run the demo end to end
+        run: ./scripts/run-demo.sh
+      - name: Tear down
+        if: always()
+        run: docker compose down -v


### PR DESCRIPTION
Adds a GitHub Actions workflow.

The `checks` job runs on every push and pull request and is fast, with no Docker stack required:
- `docker compose config -q` to validate the Compose file,
- `python3 -m py_compile verify_test.py`,
- a `bash -n` syntax check over any tracked shell scripts.

The `smoke` job builds the custom image, runs the demo, and runs the smoke test end to end. It is gated behind `workflow_dispatch` (manual) because it pulls images and downloads jars, which is too heavy for every push. It calls `scripts/run-demo.sh`, so it is most useful once that script is on the default branch.

Tested locally: the three `checks` steps all pass against the current tree, and the workflow YAML parses with the `on` triggers intact.
